### PR TITLE
[File Sync] export pojoStick as a function that syncs a file with changes in an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # pojo-stick
 :paperclip: Sync a plain-old-javascript-object with a local json file - in 1 line of code!
 
-_This project is a work in progress. PullRequests are very welcome_
+_This project is a work in progress. API is subject to change. PullRequests are very welcome_
 
+## Usage
+
+install with npm:
+
+```
+npm install --save pojo-stick
+```
+
+```js
+const pojoStick = require('pojo-stick')
+
+const obj = await pojoStick('/some/save/path')
+
+// when I change an value under `obj`, it will automatically save to the fileSystem
+obj.data = { automaticallySaves: true }
+
+// it also works with sub-properties too
+obj.data.array = []
+obj.data.array.push('I can push values!')
+```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # pojo-stick
-:paperclip: Sync a plain-old-javascript-object with a local json file - in 1 line of code!
+:paperclip: Sync a plain-old-javascript-object (POJO) with a local json file - in 1 line of code!
 
-_This project is a work in progress. API is subject to change. PullRequests are very welcome_
+_This project is a work in progress. API is subject to change. Issues, Enhancement Ideas, and Pull Requests are very welcome._
 
 ## Usage
 
-install with npm:
+Install with npm:
 
 ```
 npm install --save pojo-stick
 ```
+
+Simply require and instantiate. That's it.
 
 ```js
 const pojoStick = require('pojo-stick')
 
 const obj = await pojoStick('/some/save/path')
 
+
+// EXAMPLE:
 // when I change an value under `obj`, it will automatically save to the fileSystem
 obj.data = { automaticallySaves: true }
 
@@ -23,3 +27,11 @@ obj.data = { automaticallySaves: true }
 obj.data.array = []
 obj.data.array.push('I can push values!')
 ```
+
+Or more concisely:
+
+```js
+const data = await require('pojo-stick')('/path/to/save/data')
+```
+
+Next time you run your program, the object returned from `pojoStick` will retain whatever state it was in from the previous run. So you can get on with your program - not stress about making sure your data gets saved.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,23 @@
+const { basename, dirname } = require('path')
+const { getSyncFileObject } = require('./lib/file-safe')
+
+/**
+ * Auto-save a plain-old-javascript-object to local json file when the object changes
+ * @param {string} savePath - the path we wish to save the data to when the object changes
+ * @param {object} [defaultData] - initial data for the first time the object instantiates
+ */
+function pojoStick(savePath, defaultData = {}) {
+  // if the user only gave us a folder, save to a _probably_ safe index location
+  let filePath = savePath;
+  let fileName = '.pojo-stick.json'
+
+  // if the user gave us a specific file to save to, use that
+  if (savePath.endsWith('.json')) {
+    filePath = dirname(savePath)
+    fileName = basename(savePath)
+  }
+
+  return getSyncFileObject(filePath, fileName, defaultData)
+}
+
+module.exports = pojoStick

--- a/lib/file-safe.js
+++ b/lib/file-safe.js
@@ -1,0 +1,68 @@
+const util = require('util')
+const fs = require('fs')
+const { resolve } = require('path')
+const { createObservedObject } = require('./observable-object')
+
+const [ readFile, writeFile, exists, mkdir, rmdir ] = [ 
+  util.promisify(fs.readFile), 
+  util.promisify(fs.writeFile), 
+  util.promisify(fs.exists),
+  util.promisify(fs.mkdir),
+  util.promisify(fs.rmdir),
+]
+
+const writeFileSafely = async (dirPath, fileName, data) => {
+  const filePath = resolve(dirPath, fileName)
+  try {
+    await mkdir(dirPath, { recursive: true })
+    await writeFile(filePath, data)
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const interpret = (buffer) => {
+  const contents = buffer.toString()
+  try {
+    const json = JSON.parse(contents)
+    return json
+  } catch (err) {
+    return contents
+  }
+}
+
+const readFileSafely = async (dirPath, fileName, defaultData) => {
+  const filePath = resolve(dirPath, fileName)
+  try {
+    if (await exists(filePath)){
+      return interpret(await readFile(filePath))
+    } else {
+      await mkdir(dirPath, { recursive: true })
+      if (defaultData) {
+        writeFile(filePath, defaultData)
+      }
+      return defaultData
+    }
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+/**
+ * @function getSyncFileObject
+ * @description Create an object which auto-saves itself to the filesystem.
+ * @param {string} filePath - the folder the JSON file is stored under
+ * @param {string} fileName - the JSON file name
+ * @param {object} [defaultData] - initialize the object with default data 
+ */
+async function getSyncFileObject (filePath, fileName, defaultData = {}) {
+  const raw = await readFileSafely(filePath, fileName, JSON.stringify(defaultData))
+  return createObservedObject((root) => writeFileSafely(filePath, fileName, JSON.stringify(root)), raw)
+}
+
+module.exports = {
+  getSyncFileObject,
+  
+  // helpful with testing
+  readFile, exists, mkdir, rmdir, interpret
+}

--- a/test/pojo-stick.test.js
+++ b/test/pojo-stick.test.js
@@ -1,4 +1,38 @@
+const { resolve } = require('path')
+const { readFile, mkdir, rmdir, interpret} = require('../lib/file-safe')
+const pojoStick = require('../index')
+
+const testDir = resolve('.', 'test/data') // this is git ignored
+
+async function clearTestDir () {
+  await rmdir(testDir, { recursive: true })
+  await mkdir(testDir, { recursive: true })
+}
+
+const wait = (time = 0) => new Promise(res => setTimeout(res, time))
+
+beforeAll(() => {
+  return clearTestDir();
+});
+
+afterAll(() => {
+  return clearTestDir();
+});
+
 test.todo('pojoStick() with no args should throw')
 test.todo('pojoStick(<storage-path>) should return an empty object')
 test.todo('pojoStick(<storage-path>, <initialData>) should return a copy of the initial data param')
-test.todo('changing the returned object should reflect to filesystem')
+
+test('changing the returned object should reflect to filesystem', async () => {
+  const obj = await pojoStick(testDir)
+
+  const read1 = interpret(await readFile(resolve(testDir, '.pojo-stick.json')))
+  expect(read1).toEqual({})
+  
+  obj.test = { this: { is: { a: { successful: { test: false } } } } }
+  
+  await wait() // for file to sync
+  
+  const read2 = interpret(await readFile(resolve(testDir, '.pojo-stick.json')))
+  expect(read2.test).toEqual(obj.test)
+})


### PR DESCRIPTION
## Usage

Install with npm:

```
npm install --save pojo-stick
```

Simply require and instantiate. That's it.

```js
const pojoStick = require('pojo-stick')

const obj = await pojoStick('/some/save/path')


// EXAMPLE:
// when I change an value under `obj`, it will automatically save to the fileSystem
obj.data = { automaticallySaves: true }

// it also works with sub-properties too
obj.data.array = []
obj.data.array.push('I can push values!')
```

Or more concisely:

```js
const data = await require('pojo-stick')('/path/to/save/data')
```

Next time you run your program, the object returned from `pojoStick` will retain whatever state it was in from the previous run. So you can get on with your program - not stress about making sure your data gets saved.